### PR TITLE
refactor: The multiplayer option in the client now only accepts a function

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -328,9 +328,6 @@ export class _ClientImpl<
 
     if (!multiplayer) {
       multiplayerTransport = DummyTransport;
-    } else if (typeof multiplayer === 'string' && multiplayer === 'cartesify') {
-      multiplayerTransport = (opts: TransportOpts) =>
-        new CartesifyTransport(opts);
     } else if (typeof multiplayer === 'function') {
       multiplayerTransport = multiplayer;
     } else {


### PR DESCRIPTION
Details:

- Removed the string check for the `multiplayer` option.
- Updated the code to ensure `multiplayer` must be a function or `undefined`.