### PR TITLE
feat: add Dockerfile to examples

### DIFF
--- a/examples/backend/.gitignore
+++ b/examples/backend/.gitignore
@@ -1,0 +1,10 @@
+.cache
+yarn.lock
+yarn-error.log
+.DS_Store
+*.swp
+npm-debug.log*
+dist
+node_modules
+.vscode/*
+.parcel-cache/*

--- a/examples/backend/Dockerfile
+++ b/examples/backend/Dockerfile
@@ -1,0 +1,47 @@
+#syntax=docker.io/docker/dockerfile:1
+
+FROM --platform=linux/riscv64 cartesi/node:20.16.0-jammy-slim AS build-stage
+
+RUN <<EOF
+set -e
+apt-get update
+apt-get install -y --no-install-recommends python3 libsqlite3-dev build-essential 
+EOF
+
+WORKDIR /opt/cartesi/dapp
+COPY . .
+# we need python3 libsqlite3-dev build-essential to recompile the sqlite3
+RUN npm uninstall sqlite3 && npm install --build-from-source sqlite3
+RUN npm ci
+
+FROM --platform=linux/riscv64 cartesi/node:20.16.0-jammy-slim 
+
+ARG MACHINE_EMULATOR_TOOLS_VERSION=0.14.1
+ADD https://github.com/cartesi/machine-emulator-tools/releases/download/v${MACHINE_EMULATOR_TOOLS_VERSION}/machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb /
+RUN dpkg -i /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb \
+    && rm /machine-emulator-tools-v${MACHINE_EMULATOR_TOOLS_VERSION}.deb
+LABEL io.cartesi.rollups.sdk_version=0.6.0
+LABEL io.cartesi.rollups.ram_size=300Mi
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN <<EOF
+set -e
+apt-get update
+apt-get install -y --no-install-recommends \
+  busybox-static=1:1.30.1-7ubuntu3
+rm -rf /var/lib/apt/lists/* /var/log* /var/cache/*
+useradd --create-home --user-group dapp
+EOF
+
+WORKDIR /opt/cartesi/dapp
+COPY --from=build-stage /opt/cartesi/dapp .
+RUN chown -R dapp:dapp /opt/cartesi/dapp
+RUN chmod -R 761 /opt/cartesi/dapp
+USER dapp
+
+ENV ROLLUP_HTTP_SERVER_URL="http:127.0.0.1:5004"
+
+ENTRYPOINT ["rollup-init"]
+
+CMD ["yarn", "start"]

--- a/examples/backend/Game.ts
+++ b/examples/backend/Game.ts
@@ -1,0 +1,58 @@
+import { Ctx, Game } from '@think-and-dev/cartesi-boardgame/client';
+
+interface G {
+  cells: Array<string | null>;
+}
+
+const clickCell = ({ G, playerID }: { G: G; playerID: string }, id: number) => {
+  if (G.cells[id] !== null) {
+    return 'INVALID_MOVE';
+  }
+  G.cells[id] = playerID;
+};
+
+// Return true if `cells` is in a winning configuration.
+function IsVictory(cells: Array<string | null>): boolean {
+  const positions = [
+    [0, 1, 2],
+    [3, 4, 5],
+    [6, 7, 8],
+    [0, 3, 6],
+    [1, 4, 7],
+    [2, 5, 8],
+    [0, 4, 8],
+    [2, 4, 6],
+  ];
+
+  const isRowComplete = (row: number[]): boolean => {
+    const symbols = row.map((i) => cells[i]);
+    return symbols.every((i) => i !== null && i === symbols[0]);
+  };
+
+  return positions.map(isRowComplete).some((i) => i === true);
+}
+
+// Return true if all `cells` are occupied.
+function IsDraw(cells: Array<string | null>): boolean {
+  return cells.filter((c) => c === null).length === 0;
+}
+
+export const TicTacToe: Game<G> = {
+  setup: (): G => ({ cells: Array(9).fill(null) }),
+  turn: {
+    minMoves: 1,
+    maxMoves: 1,
+  },
+  moves: {
+    clickCell,
+  },
+
+  endIf: ({ G, ctx }: { G: G; ctx: Ctx }) => {
+    if (IsVictory(G.cells)) {
+      return { winner: ctx.currentPlayer };
+    }
+    if (IsDraw(G.cells)) {
+      return { draw: true };
+    }
+  },
+};

--- a/examples/backend/app.ts
+++ b/examples/backend/app.ts
@@ -1,0 +1,14 @@
+import { Server, Sqlite } from '@think-and-dev/cartesi-boardgame/server';
+import { TicTacToe } from './Game';
+
+const database = new Sqlite();
+async function main() {
+  const server = Server({
+    games: [TicTacToe],
+    db: database,
+    origins: ['http://localhost:1234'],
+  });
+
+  server.run(8000);
+}
+main().catch(console.error);

--- a/examples/backend/babel.config.js
+++ b/examples/backend/babel.config.js
@@ -1,0 +1,22 @@
+module.exports = {
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        modules: false,
+        exclude: ['transform-regenerator', 'transform-async-to-generator'],
+      },
+    ],
+    '@babel/preset-react',
+    '@babel/typescript',
+  ],
+  env: {
+    test: {
+      plugins: ['@babel/plugin-transform-modules-commonjs'],
+    },
+  },
+  plugins: [
+    '@babel/plugin-proposal-class-properties',
+    '@babel/proposal-object-rest-spread',
+  ],
+};

--- a/examples/backend/package.json
+++ b/examples/backend/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "playground",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.ts",
+  "scripts": {
+    "dev": "ROLLUP_HTTP_SERVER_URL=\"http://127.0.0.1:5004\" yarn start",
+    "dev-local": "NONODO_HTTP_SERVER_URL=\"http://127.0.0.1:8080\" yarn start",
+    "start": "babel-node --extensions \".ts,.js\" --presets @babel/preset-env ./app.ts"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@calindra/cartesify-backend": "1.0.1",
+    "@think-and-dev/cartesi-boardgame": "0.0.29-beta",
+    "sqlite3": "^5.1.7",
+    "ts-node": "^10.9.2",
+    "tsc": "^2.0.4",
+    "typescript": "^5.4.5"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.16.0",
+    "@babel/core": "^7.16.0",
+    "@babel/node": "^7.16.0",
+    "@babel/plugin-proposal-class-properties": "^7.16.0",
+    "@babel/plugin-proposal-object-rest-spread": "^7.16.0",
+    "@babel/plugin-transform-modules-commonjs": "^7.16.0",
+    "@babel/preset-env": "^7.16.0",
+    "@babel/preset-react": "^7.16.0",
+    "@babel/preset-typescript": "^7.16.0",
+    "@types/node": "16"
+  }
+}

--- a/examples/backend/tsconfig.json
+++ b/examples/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "declaration": false,
+    "module": "commonjs",  
+    "target": "es6",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "strict": true
+  },
+  "include": ["./app.ts"],
+}


### PR DESCRIPTION
Feat:
Added backend folder to examples for running a full cartesi example. The following list of files were added:
- Dockerfile
- Game.ts
- app.ts
- package.json
- tsconfig.json

Related Task:
[CARBG-55](https://thinkanddev.atlassian.net/browse/CARBG-55)

[CARBG-55]: https://thinkanddev.atlassian.net/browse/CARBG-55?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ